### PR TITLE
Remove unused Babel plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,8 +4,5 @@
             "@babel/preset-env",
             { "modules": false },
         ],
-    ],
-    "plugins": [
-        "@babel/plugin-proposal-function-bind"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     },
     "devDependencies": {
         "@babel/core": "^7.3.3",
-        "@babel/plugin-proposal-function-bind": "^7.2.0",
         "@babel/preset-env": "^7.3.1",
         "@commitlint/cli": "^7.5.2",
         "@commitlint/config-conventional": "^7.5.0",


### PR DESCRIPTION
**Summary**

Remove unused Babel plugin prevents build with Webpack

**What kind of change does this PR introduce?**

- [x] Bug fix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [x] Build-related changes
- [ ] Other, please describe:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following platforms: (Providing a detailed version will be better.)

- [x] PC
- [x] iOS
- [x] Android

If it's convenient:

![photo_2019-05-27_18-08-30](https://user-images.githubusercontent.com/846774/58405391-a7d41300-80aa-11e9-8591-01339bba38cb.jpg)