### PR TITLE
fixed android smooth scroll

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,10 @@ const setOverflowHiddenMobile = () => {
             $body.style[x] = bodyStyle[x] || ''
         })
 
-        window.scrollTo(0, scrollTop)
+        window.scrollTo({
+            top: scrollTop,
+            behavior: 'instant'
+        })
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ let documentListenerAdded = false
 
 const lockedElements: HTMLElement[] = []
 const eventListenerOptions = getEventListenerOptions({ passive: false })
+const supportsNativeSmoothScroll = !isServer && 'scrollBehavior' in document.documentElement.style
 
 const setOverflowHiddenPc = () => {
     const $body = document.body
@@ -57,10 +58,12 @@ const setOverflowHiddenMobile = () => {
             $body.style[x] = bodyStyle[x] || ''
         })
 
-        window.scrollTo({
-            top: scrollTop,
-            behavior: 'instant'
-        })
+        supportsNativeSmoothScroll
+          ? window.scrollTo({
+              top: scrollTop,
+              behavior: 'instant'
+            })
+          : window.scrollTo(0, scrollTop)
     }
 }
 


### PR DESCRIPTION
当页面设置了平滑滚动时，锁屏的滚动也会变成 smooth，所以强制`behavior`为`instant`